### PR TITLE
Wrong validation of metabase response

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,0 +1,20 @@
+[bumpversion]
+current_version = 1.4.1
+commit = True
+tag = False
+parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<release>[a-z]+)(?P<build>\d+))?
+serialize = 
+	{major}.{minor}.{patch}-{release}{build}
+	{major}.{minor}.{patch}
+
+[bumpversion:part:release]
+optional_value = prod
+first_value = dev
+values = 
+	dev
+	prod
+
+[bumpversion:part:build]
+
+[bumpversion:file:VERSION]
+

--- a/metabasepy/table_parser.py
+++ b/metabasepy/table_parser.py
@@ -45,7 +45,7 @@ class MetabaseTableParser(object):
             raise MetabaseResultInvalidException()
 
         data_requirements = {
-            'columns',
+            'cols',
             'rows',
             'native_form'
         }
@@ -66,7 +66,7 @@ class MetabaseTableParser(object):
         table = MetabaseTable()
         table.rows = metabase_response['data']['rows']
 
-        table.columns = metabase_response['data']['columns']
+        table.cols = metabase_response['data']['cols']
         table.native_query = metabase_response['data']['native_form']['query']
         table.status = metabase_response['status']
         table.database = metabase_response['json_query']['database']


### PR DESCRIPTION
As mentioned here:
https://github.com/mertsalik/metabasepy/issues/18

MetabaseTableParser -> validate_metabase_response validate data requirements with wrong keywords.

@brad-nelson-va fixed it before i even notice. Thanks.